### PR TITLE
🐛 Fix issue where 'mediaItems' is missing from request

### DIFF
--- a/gparch.py
+++ b/gparch.py
@@ -472,7 +472,8 @@ class PhotosAccount(object):
         while True:
             if self.debug:
                 save_json(request, 'debug/favorites' + str(num) + '.json')
-            favorites_list += request["mediaItems"]
+            if "mediaItems" in request:
+                favorites_list += request["mediaItems"]
             if "nextPageToken" in request:
                 request_body["pageToken"] = request["nextPageToken"]
                 request = self.service.mediaItems().search(body=request_body).execute()

--- a/gparch.py
+++ b/gparch.py
@@ -392,7 +392,8 @@ class PhotosAccount(object):
         while True:
             if self.debug:
                 save_json(request, 'debug/media' + str(num) + '.json')
-            media_items_list += request["mediaItems"]
+            if "mediaItems" in request:
+                media_items_list += request["mediaItems"]
             if "nextPageToken" in request:
                 next_page = request["nextPageToken"]
                 request = (

--- a/gparch.py
+++ b/gparch.py
@@ -346,7 +346,8 @@ class PhotosAccount(object):
             self.service.mediaItems().search(body=request_body).execute()
         )  # 100 is max
         while True:
-            album_items += request["mediaItems"]
+            if "mediaItems" in request:
+                album_items += request["mediaItems"]
             if "nextPageToken" in request:
                 request_body["pageToken"] = request["nextPageToken"]
                 request = self.service.mediaItems().search(body=request_body).execute()


### PR DESCRIPTION
Very small fix, only add `mediaItems` to the list if they actually exist.

This exception is caused by a request looking like below, missing the `mediaItems` but still having a `nextPageToken`:

```python
>>> print(request)
{'nextPageToken': 'abcabc'}
>>> media_items_list += request["mediaItems"]

Traceback (most recent call last):
  File "/Volumes/Homesweet/GooglePhotoArchiver/gparch_cli.py", line 127, in <module>
    account.download_library()
  File "/Volumes/Homesweet/GooglePhotoArchiver/gparch.py", line 281, in download_library
    items = self.process_media_items(self.list_media_items(), self.lib_dir)
  File "/Volumes/Homesweet/GooglePhotoArchiver/gparch.py", line 356, in list_media_items
    media_items_list += request["mediaItems"]
KeyError: 'mediaItems'
```

Fixes #6